### PR TITLE
Fix path context naming collision

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'dart:math';
 import 'package:facesdk_plugin/facesdk_plugin.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_exif_rotation/flutter_exif_rotation.dart';
-import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -186,7 +186,7 @@ class MyHomePageState extends State<MyHomePage> {
       // Set the path to the database. Note: Using the `join` function from the
       // `path` package is best practice to ensure the path is correctly
       // constructed for each platform.
-      join(await getDatabasesPath(), 'person.db'),
+      p.join(await getDatabasesPath(), 'person.db'),
       // When the database is first created, create a table to store dogs.
       onCreate: (db, version) {
         // Run the CREATE TABLE statement on the database.


### PR DESCRIPTION
## Summary
- avoid name collision by aliasing `package:path`
- update database path code to use alias

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab087c9c48330ad341e1e0e89ba93