### PR TITLE
Fix unmatched parentheses in Dart views

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -625,6 +625,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
         ),
       ),
     );
+    ); // Close WillPopScope
   }
 }
 

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -340,6 +340,8 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
         ),
       ),
     );
+    ); // Close WillPopScope
+    
   }
 }
 


### PR DESCRIPTION
## Summary
- close `WillPopScope` widgets properly in `facedetectionview.dart` and `facecaptureview.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ac5d9353483308de311796743dce3