### PR TITLE
Fix closing parentheses and add math import

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:ui' as ui;
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -624,7 +625,6 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
           ],
         ),
       ),
-    );
     ); // Close WillPopScope
   }
 }

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -339,7 +339,6 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
           ],
         ),
       ),
-    );
     ); // Close WillPopScope
     
   }


### PR DESCRIPTION
## Summary
- fix unbalanced closing parentheses in `FaceDetectionView` and `FaceCaptureView`
- add missing `dart:math` import required for `cos`, `sin`, etc.

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_685ac78d94b88330bcfe8b3209ee7fbf