### PR TITLE
Fix closing parens in Flutter views

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -625,7 +625,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
           ],
         ),
       ),
-      );
+      )
     ); // Close WillPopScope
   }
 }

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -339,7 +339,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
           ],
         ),
       ),
-      );
+      )
     ); // Close WillPopScope
     
   }


### PR DESCRIPTION
## Summary
- correct closing of `Scaffold` widgets in `facedetectionview` and `facecaptureview`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad314c1ec8330bea390cbcd9ab26e