### PR TITLE
Fix logger e call for build

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -23,6 +23,10 @@ class AppLogger {
   }
 
   static void e(String message, [dynamic error, StackTrace? stackTrace]) {
-    _logger.e(message, error, stackTrace);
+    _logger.e(
+      message,
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- fix logger's error method call by using named parameters

## Testing
- `which flutter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9f33a87083308680e809d405abb3