### PR TITLE
Integrate InsightFace age estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ To run this repo successfully, license should be required based on each `applica
   flutter clean
   flutter pub get
   flutter run
-  ```  
+  ```
+### 3. InsightFace Age Model
+  This project can optionally estimate age using [InsightFace](https://github.com/deepinsight/insightface).
+  Download `genderage.onnx` from the InsightFace releases and place it under `assets/genderage.onnx`.
+  The application will load this model at runtime using the `onnxruntime` package.
   If you plan to run the iOS app, please refer to the following [link](https://docs.flutter.dev/deployment/ios) for detailed instructions.</br>
 ## About SDK
 ### 1. Setup

--- a/assets/genderage.onnx
+++ b/assets/genderage.onnx
@@ -1,0 +1,1 @@
+Please download genderage.onnx from InsightFace releases and place it here.

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:facesdk_plugin/facedetection_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:facesdk_plugin/facesdk_plugin.dart';
+import 'insightface_age_estimator.dart';
 import 'logger.dart';
 import 'person.dart';
 import 'recognition_log.dart';
@@ -122,7 +123,13 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
           maxYaw = face['yaw'];
           maxRoll = face['roll'];
           maxPitch = face['pitch'];
-          maxAge = face['age'];
+          // Override age using InsightFace estimator
+          try {
+            maxAge = await InsightFaceAgeEstimator.instance
+                .estimateAge(face['faceJpg']);
+          } catch (_) {
+            maxAge = face['age'];
+          }
           maxGender = face['gender'];
           identifedFace = face['faceJpg'];
           enrolledFace = person.faceJpg;

--- a/lib/insightface_age_estimator.dart
+++ b/lib/insightface_age_estimator.dart
@@ -34,16 +34,18 @@ class InsightFaceAgeEstimator {
     for (int y = 0; y < inputSize; y++) {
       for (int x = 0; x < inputSize; x++) {
         final pixel = resized.getPixel(x, y);
-        buffer[index++] = img.getBlue(pixel).toDouble();
-        buffer[index++] = img.getGreen(pixel).toDouble();
-        buffer[index++] = img.getRed(pixel).toDouble();
+        // The image package returns a Pixel object with r, g, b getters.
+        buffer[index++] = pixel.b.toDouble();
+        buffer[index++] = pixel.g.toDouble();
+        buffer[index++] = pixel.r.toDouble();
       }
     }
 
     final inputTensor =
         OrtValueTensor.createTensorWithDataList(buffer, [1, 3, inputSize, inputSize]);
     final outputs = _session!.run(OrtRunOptions(), {'data': inputTensor});
-    final List<double> result = outputs.first!.value.cast<double>();
+    final List<double> result =
+        (outputs.first!.value as List<dynamic>).cast<double>();
     inputTensor.release();
     outputs.forEach((e) => e?.release());
 

--- a/lib/insightface_age_estimator.dart
+++ b/lib/insightface_age_estimator.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:image/image.dart' as img;
+import 'package:onnxruntime/onnxruntime.dart';
+
+class InsightFaceAgeEstimator {
+  InsightFaceAgeEstimator._();
+  static final InsightFaceAgeEstimator instance = InsightFaceAgeEstimator._();
+
+  OrtSession? _session;
+  bool _initialized = false;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    OrtEnv.instance.init();
+    final sessionOptions = OrtSessionOptions();
+    final raw = await rootBundle.load('assets/genderage.onnx');
+    _session = OrtSession.fromBuffer(raw.buffer.asUint8List(), sessionOptions);
+    sessionOptions.release();
+    _initialized = true;
+  }
+
+  Future<int> estimateAge(Uint8List imageBytes) async {
+    await init();
+    final image = img.decodeImage(imageBytes);
+    if (image == null) {
+      throw Exception('Invalid image bytes');
+    }
+    const inputSize = 96;
+    final resized = img.copyResize(image, width: inputSize, height: inputSize);
+
+    final buffer = Float32List(inputSize * inputSize * 3);
+    var index = 0;
+    for (int y = 0; y < inputSize; y++) {
+      for (int x = 0; x < inputSize; x++) {
+        final pixel = resized.getPixel(x, y);
+        buffer[index++] = img.getBlue(pixel).toDouble();
+        buffer[index++] = img.getGreen(pixel).toDouble();
+        buffer[index++] = img.getRed(pixel).toDouble();
+      }
+    }
+
+    final inputTensor =
+        OrtValueTensor.createTensorWithDataList(buffer, [1, 3, inputSize, inputSize]);
+    final outputs = _session!.run(OrtRunOptions(), {'data': inputTensor});
+    final List<double> result = outputs.first!.value.cast<double>();
+    inputTensor.release();
+    outputs.forEach((e) => e?.release());
+
+    final age = (result[2] * 100).round();
+    return age;
+  }
+
+  void dispose() {
+    _session?.release();
+    _session = null;
+    if (_initialized) {
+      OrtEnv.instance.release();
+      _initialized = false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   image_picker: ^1.1.2
   sqflite: ^2.4.2
   logger: ^2.0.2
+  onnxruntime: ^1.4.1
+  image: ^4.1.3
 
 dev_dependencies:
   flutter_test:
@@ -76,6 +78,7 @@ flutter:
     - assets/ic_telegram.png
     - assets/ic_whatsapp.png
     - assets/ic_github.png
+    - assets/genderage.onnx
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
## Summary
- add InsightFace ONNX model placeholder
- integrate `onnxruntime` and `image` dependencies
- implement `InsightFaceAgeEstimator` for age prediction
- use estimator in face detection flow
- document how to download and use the ONNX model

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec5f7b1ec83309fbc0de2620cb6c9