### PR TITLE
Improve log viewing UX

### DIFF
--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -74,6 +74,9 @@ class AppLocalizations {
       'female': 'Female',
       'enterName': 'Enter name',
       'tryAgain': 'Try again',
+      'logDetails': 'Log Details',
+      'name': 'Name: ',
+      'time': 'Time: ',
       'aboutTitle': 'OGULCAN-AI Technology',
       'aboutContent':
           'The Face Recognition System application provides secure and contactless access to buildings using advanced AI and biometric technologies. While it allows only authorized persons to enter, it also simplifies visitor management.\n\nThis project was created by software developer Ogulcan Topal with the dream of making technology a part of daily life. Developed with data privacy and security in mind, it is constantly updated to provide the best user experience.\n\nAbout the developer:\nOgulcan Topal is a developer passionate about artificial intelligence, mobile software, and automation systems. This application reflects his vision of modernizing security with practical solutions.'
@@ -142,6 +145,9 @@ class AppLocalizations {
       'female': 'Kadın',
       'enterName': 'İsim girin',
       'tryAgain': 'Tekrar dene',
+      'logDetails': 'Kayıt Detayları',
+      'name': 'İsim: ',
+      'time': 'Zaman: ',
       'aboutTitle': 'OGULCAN-AI Teknoloji',
       'aboutContent':
           'Yüz Tanıma Sistemi uygulaması, gelişmiş yapay zeka ve biyometrik teknolojilerle desteklenen, binalara güvenli ve temassız erişim sağlamak üzere geliştirilmiştir. Bu uygulama, yalnızca yetkili kişilerin giriş yapmasına olanak tanırken, aynı zamanda ziyaretçi yönetimini de kolaylaştırır.\n\nBu proje, teknolojiyi günlük hayatın bir parçası haline getirme hayaliyle, yazılım geliştiricisi Oğulcan Topal tarafından tasarlanmış ve hayata geçirilmiştir. Uygulama, veri gizliliği ve güvenliği esas alınarak geliştirilmiş olup, kullanıcı deneyimini en üst seviyede tutmak için sürekli olarak güncellenmektedir.\n\nGeliştirici Hakkında:\nOğulcan Topal, yapay zeka, mobil yazılım ve otomasyon sistemlerine tutkuyla bağlı bir geliştiricidir. Bu uygulama, onun pratik çözümlerle güvenliği modernleştirme vizyonunun bir yansımasıdır.'

--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'recognition_log.dart';
+import 'localization.dart';
+
+class LogDetailView extends StatelessWidget {
+  final RecognitionLog log;
+  const LogDetailView({super.key, required this.log});
+
+  @override
+  Widget build(BuildContext context) {
+    String genderText = log.gender == 0
+        ? AppLocalizations.of(context).t('male')
+        : AppLocalizations.of(context).t('female');
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context).t('logDetails')),
+        toolbarHeight: 70,
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${AppLocalizations.of(context).t('name')}${log.name}'),
+              const SizedBox(height: 8),
+              Text('${AppLocalizations.of(context).t('time')}${log.time}'),
+              const SizedBox(height: 8),
+              Text('${AppLocalizations.of(context).t('age')}${log.age}'),
+              const SizedBox(height: 8),
+              Text('${AppLocalizations.of(context).t('gender')}$genderText'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/logview.dart
+++ b/lib/logview.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
+import 'log_detail_view.dart';
 
 class LogView extends StatelessWidget {
   final List<RecognitionLog> logList;
@@ -21,14 +22,17 @@ class LogView extends StatelessWidget {
                 itemCount: logList.length,
                 itemBuilder: (context, index) {
                   final log = logList[index];
-                  String genderText =
-                      log.gender == 0
-                          ? AppLocalizations.of(context).t('male')
-                          : AppLocalizations.of(context).t('female');
                   return ListTile(
                     title: Text(log.name),
-                    subtitle: Text(
-                        "${log.time}\n${AppLocalizations.of(context).t('age')}${log.age}, ${AppLocalizations.of(context).t('gender')}$genderText"),
+                    subtitle: Text(log.time),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => LogDetailView(log: log),
+                        ),
+                      );
+                    },
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- add page to show log details
- simplify log list and open detail page on tap
- localize new strings for log details

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee04218a0833087b84cf7789a0b6c