### PR TITLE
Improve time formatting in logs

### DIFF
--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -25,7 +25,7 @@ class LogDetailView extends StatelessWidget {
             children: [
               Text('${AppLocalizations.of(context).t('name')}${log.name}'),
               const SizedBox(height: 8),
-              Text('${AppLocalizations.of(context).t('time')}${log.time}'),
+              Text('${AppLocalizations.of(context).t('time')}${log.formattedTime}'),
               const SizedBox(height: 8),
               Text('${AppLocalizations.of(context).t('age')}${log.age}'),
               const SizedBox(height: 8),

--- a/lib/logview.dart
+++ b/lib/logview.dart
@@ -24,7 +24,7 @@ class LogView extends StatelessWidget {
                   final log = logList[index];
                   return ListTile(
                     title: Text(log.name),
-                    subtitle: Text(log.time),
+                    subtitle: Text(log.formattedTime),
                     onTap: () {
                       Navigator.push(
                         context,

--- a/lib/recognition_log.dart
+++ b/lib/recognition_log.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 class RecognitionLog {
   final String name;
   final String time;
@@ -26,5 +28,14 @@ class RecognitionLog {
       'age': age,
       'gender': gender,
     };
+  }
+
+  String get formattedTime {
+    try {
+      final parsed = DateTime.parse(time);
+      return DateFormat('yyyy-MM-dd HH:mm:ss').format(parsed);
+    } catch (_) {
+      return time;
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   image_picker: ^1.1.2
   sqflite: ^2.4.2
   logger: ^2.0.2
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- display log timestamps in a readable format
- use `intl` package for date formatting

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5eda9248330b55bc31720658e52