### PR TITLE
Update intl dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   image_picker: ^1.1.2
   sqflite: ^2.4.2
   logger: ^2.0.2
-  intl: ^0.18.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update `intl` to `^0.19.0` to match Flutter SDK requirements

## Testing
- `flutter pub get` *(fails: `bash: flutter: command not found`)*
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ef271ad1c8330b516a09efaee86f4