### PR TITLE
Fix theme compatibility for warning messages

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -550,11 +550,10 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
               margin: const EdgeInsets.only(right: 20, top: 64),
               alignment: Alignment.topRight,
               child: Text(
-                _warningTxt, // Equivalent to android:text=""
-                style: const TextStyle(
-                  color: Colors
-                      .redAccent, // Equivalent to android:textColor="@android:color/holo_red_light"
-                  fontSize: 16, // Equivalent to android:textSize="16sp"
+                _warningTxt,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontSize: 16,
                 ),
               ), // Equivalent to constraintEnd_toEndOf and constraintTop_toTopOf
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -606,12 +606,17 @@ class MyHomePageState extends State<MyHomePage> {
                         child: Container(
                           width: double.infinity,
                           height: 40,
-                          color: Colors.redAccent,
+                          color:
+                              Theme.of(context).colorScheme.errorContainer,
                           child: Center(
                             child: Text(
                               _warningState,
                               textAlign: TextAlign.center,
-                              style: const TextStyle(fontSize: 20),
+                              style: TextStyle(
+                                  fontSize: 20,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onErrorContainer),
                             ),
                           ),
                         ))


### PR DESCRIPTION
## Summary
- use theme colors for main page info box
- apply error color to Face Capture warnings

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f0019419883308d6e64505247c71d