### PR TITLE
Fix startup freeze

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,8 +137,11 @@ class MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-
-    init();
+    // Delay heavy initialization until after the first frame so that
+    // the UI can render without blocking on native plugin calls.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      init();
+    });
   }
 
   Future<void> init() async {


### PR DESCRIPTION
## Summary
- delay heavy initialization until after the first frame is rendered

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c06314c8330ab52ad6d522cadbe