### PR TITLE
Fix FaceSDK plugin with ProGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ To run this repo successfully, license should be required based on each `applica
     import 'package:facesdk_plugin/facesdk_plugin.dart';
     import 'package:facesdk_plugin/facedetection_interface.dart';
   ```
+  - If you enable code shrinking (`minifyEnabled true`), make sure the plugin
+    classes are kept by adding the following rule to `android/app/proguard-rules.pro`:
+    ```
+    -keep class com.kbyai.facesdk_plugin.** {*;}
+    ```
 ### 2 API Usages
 #### 2.1 Facesdk Plugin
   - Activate the `FacesdkPlugin` by calling the `setActivation` method:

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,3 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -keep class com.kbyai.facesdk.** {*;}
+-keep class com.kbyai.facesdk_plugin.** {*;}


### PR DESCRIPTION
## Summary
- keep FaceSDK plugin classes when using ProGuard
- document ProGuard rule in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f142e89208330bfe73efb05b82d1c