### PR TITLE
Fix unreadable text in detection screens

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -576,7 +576,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
                             ),
                             Text(
                               _capturedLiveness,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -590,7 +590,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
                             ),
                             Text(
                               _capturedQuality,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -604,7 +604,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
                             ),
                             Text(
                               _capturedLuminance,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -271,7 +271,11 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('identifiedName') +
                                   _identifiedName,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(
+                                  fontSize: 18,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onBackground),
                             )
                           ],
                         ),
@@ -286,7 +290,11 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('similarity') +
                                   _identifiedSimilarity,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(
+                                  fontSize: 18,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onBackground),
                             )
                           ],
                         ),
@@ -301,7 +309,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('livenessScore') +
                                   _identifiedLiveness,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -316,7 +324,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('yaw') +
                                   _identifiedYaw,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -331,7 +339,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('roll') +
                                   _identifiedRoll,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -346,7 +354,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                             Text(
                               AppLocalizations.of(context).t('pitch') +
                                   _identifiedPitch,
-                              style: const TextStyle(fontSize: 18),
+                              style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                             )
                           ],
                         ),
@@ -363,7 +371,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                               Text(
                                 AppLocalizations.of(context).t('age') +
                                     _identifiedAge,
-                                style: const TextStyle(fontSize: 18),
+                                style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                               )
                             ],
                           ),
@@ -381,7 +389,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                               Text(
                                 AppLocalizations.of(context).t('gender') +
                                     _identifiedGender,
-                                style: const TextStyle(fontSize: 18),
+                                style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onBackground),
                               )
                             ],
                           ),


### PR DESCRIPTION
## Summary
- adjust text colors in `FaceDetectionView` and `FaceCaptureView` so they follow the active theme

## Testing
- `dart format -o none lib/facedetectionview.dart lib/facecaptureview.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3d8d2ffc8330b6bfae858476d190