### PR TITLE
Fix overlay color in face capture

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -779,8 +779,14 @@ class _CaptureViewState extends State<CaptureView>
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter:
-          CapturePainter(_animation.value, widget.viewMode, widget.currentFace),
+      painter: CapturePainter(
+        _animation.value,
+        widget.viewMode,
+        widget.currentFace,
+        Theme.of(context).brightness == Brightness.light
+            ? Colors.white
+            : Colors.black,
+      ),
       child: Container(),
     );
   }
@@ -792,9 +798,11 @@ class CapturePainter extends CustomPainter {
   bool scrimInited = false;
   final Paint eraserPaint;
   final dynamic currentFace;
+  final Color overlayColor;
   late ui.Image roiImage;
 
-  CapturePainter(this.animateValue, this.viewMode, this.currentFace)
+  CapturePainter(
+      this.animateValue, this.viewMode, this.currentFace, this.overlayColor)
       : eraserPaint = Paint()
           ..color = Colors.transparent
           ..blendMode = BlendMode.clear;
@@ -802,7 +810,7 @@ class CapturePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) async {
     final Paint overlayPaint = Paint()
-      ..color = Colors.black
+      ..color = overlayColor
       ..style = PaintingStyle.fill;
 
     // Draw a full-screen rectangle with overlay paint


### PR DESCRIPTION
## Summary
- adapt capture overlay background to match the current theme

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f419918b08330917dab99fa4d1f5c