### PR TITLE
Replace neumorphic buttons with Material equivalents

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,15 +137,14 @@ class MyHomePageState extends State<MyHomePage> {
 
   final _facesdkPlugin = FacesdkPlugin();
 
-  NeumorphicStyle _buttonStyle(BuildContext context) {
+  ButtonStyle _buttonStyle(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    return NeumorphicStyle(
-        shape: NeumorphicShape.flat,
-        boxShape: const NeumorphicBoxShape.stadium(),
-        color: scheme.primaryContainer,
-        depth: isDark ? 1 : 2,
-        intensity: 0.8);
+    return FilledButton.styleFrom(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      backgroundColor: scheme.primaryContainer,
+      foregroundColor: scheme.onPrimaryContainer,
+      shape: const StadiumBorder(),
+    );
   }
 
   @override
@@ -511,8 +510,7 @@ class MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 Expanded(
                   flex: 1,
-                  child: NeumorphicButton(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: FilledButton(
                       style: _buttonStyle(context),
                       onPressed: enrollPerson,
                       child: Row(
@@ -534,8 +532,7 @@ class MyHomePageState extends State<MyHomePage> {
                 const SizedBox(width: 20),
                 Expanded(
                   flex: 1,
-                  child: NeumorphicButton(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: FilledButton(
                       style: _buttonStyle(context),
                       onPressed: () {
                         Navigator.push(
@@ -570,8 +567,7 @@ class MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 Expanded(
                   flex: 1,
-                  child: NeumorphicButton(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: FilledButton(
                       style: _buttonStyle(context),
                       onPressed: () {
                         Navigator.push(
@@ -601,8 +597,7 @@ class MyHomePageState extends State<MyHomePage> {
                 const SizedBox(width: 20),
                 Expanded(
                   flex: 1,
-                  child: NeumorphicButton(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: FilledButton(
                       style: _buttonStyle(context),
                       onPressed: () {
                         Navigator.push(
@@ -638,8 +633,7 @@ class MyHomePageState extends State<MyHomePage> {
             Row(
               children: <Widget>[
                 Expanded(
-                  child: NeumorphicButton(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: FilledButton(
                       style: _buttonStyle(context),
                       onPressed: () {
                         Navigator.push(

--- a/lib/personview.dart
+++ b/lib/personview.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'person.dart';
 import 'main.dart';
 
@@ -31,28 +30,20 @@ class _PersonViewState extends State<PersonView> {
     return ListView.builder(
         itemCount: widget.personList.length,
         itemBuilder: (BuildContext context, int index) {
-          return SizedBox(
-              height: 75,
-              child: Neumorphic(
-                  style: const NeumorphicStyle(depth: -2),
-                  child: Row(
+          return Card(
+            child: ListTile(
+              leading: ClipRRect(
+                borderRadius: BorderRadius.circular(28.0),
+                child: Image.memory(
+                  widget.personList[index].faceJpg,
+                  width: 56,
+                  height: 56,
+                ),
+              ),
+              title: Text(widget.personList[index].name),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  const SizedBox(
-                    width: 16,
-                  ),
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(28.0),
-                    child: Image.memory(
-                      widget.personList[index].faceJpg,
-                      width: 56,
-                      height: 56,
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 16,
-                  ),
-                  Text(widget.personList[index].name),
-                  const Spacer(),
                   IconButton(
                     icon: const Icon(Icons.edit),
                     onPressed: () => renamePerson(index),
@@ -61,11 +52,10 @@ class _PersonViewState extends State<PersonView> {
                     icon: const Icon(Icons.delete),
                     onPressed: () => deletePerson(index),
                   ),
-                  const SizedBox(
-                    width: 8,
-                  )
                 ],
-              )));
+              ),
+            ),
+          );
         });
   }
 }


### PR DESCRIPTION
## Summary
- use Material buttons instead of `NeumorphicButton`
- convert `_buttonStyle` to return a Material `ButtonStyle`
- display people with `Card` + `ListTile` instead of neumorphic containers

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f635a40648330865fc7e43e4a624b