### PR TITLE
Replace fluttertoast with SnackBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:image_picker/image_picker.dart';
 import 'package:flutter_exif_rotation/flutter_exif_rotation.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'dart:io' show Platform;
@@ -349,14 +348,13 @@ class MyHomePageState extends State<MyHomePage> {
       personList.clear();
     });
 
-    Fluttertoast.showToast(
-        msg: AppLocalizations.of(context).t('allPersonDeleted'),
-        toastLength: Toast.LENGTH_SHORT,
-        gravity: ToastGravity.BOTTOM,
-        timeInSecForIosWeb: 1,
-        backgroundColor: Colors.red,
-        textColor: Colors.white,
-        fontSize: 16.0);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(AppLocalizations.of(context).t('allPersonDeleted'),
+          style: TextStyle(
+              color: Theme.of(context).colorScheme.onErrorContainer)),
+      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+      duration: const Duration(seconds: 1),
+    ));
   }
 
   Future<void> deletePerson(index) async {
@@ -371,14 +369,13 @@ class MyHomePageState extends State<MyHomePage> {
       personList.removeAt(index);
     });
 
-    Fluttertoast.showToast(
-        msg: AppLocalizations.of(context).t('personRemoved'),
-        toastLength: Toast.LENGTH_SHORT,
-        gravity: ToastGravity.BOTTOM,
-        timeInSecForIosWeb: 1,
-        backgroundColor: Colors.red,
-        textColor: Colors.white,
-        fontSize: 16.0);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(AppLocalizations.of(context).t('personRemoved'),
+          style: TextStyle(
+              color: Theme.of(context).colorScheme.onErrorContainer)),
+      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+      duration: const Duration(seconds: 1),
+    ));
   }
 
   Future<void> updatePersonName(int index, String newName) async {
@@ -393,14 +390,13 @@ class MyHomePageState extends State<MyHomePage> {
           templates: personList[index].templates);
     });
 
-    Fluttertoast.showToast(
-        msg: AppLocalizations.of(context).t('personRenamed'),
-        toastLength: Toast.LENGTH_SHORT,
-        gravity: ToastGravity.BOTTOM,
-        timeInSecForIosWeb: 1,
-        backgroundColor: Colors.red,
-        textColor: Colors.white,
-        fontSize: 16.0);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(AppLocalizations.of(context).t('personRenamed'),
+          style: TextStyle(
+              color: Theme.of(context).colorScheme.onErrorContainer)),
+      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+      duration: const Duration(seconds: 1),
+    ));
   }
 
   Future<String?> requestPersonName() async {
@@ -454,24 +450,22 @@ class MyHomePageState extends State<MyHomePage> {
         insertPerson(person);
       }
 
-      if (faces.length == 0) {
-        Fluttertoast.showToast(
-            msg: AppLocalizations.of(context).t('noFaceDetected'),
-            toastLength: Toast.LENGTH_SHORT,
-            gravity: ToastGravity.BOTTOM,
-            timeInSecForIosWeb: 1,
-            backgroundColor: Colors.red,
-            textColor: Colors.white,
-            fontSize: 16.0);
+      if (faces.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(AppLocalizations.of(context).t('noFaceDetected'),
+              style: TextStyle(
+                  color: Theme.of(context).colorScheme.onErrorContainer)),
+          backgroundColor: Theme.of(context).colorScheme.errorContainer,
+          duration: const Duration(seconds: 1),
+        ));
       } else {
-        Fluttertoast.showToast(
-            msg: AppLocalizations.of(context).t('personEnrolled'),
-            toastLength: Toast.LENGTH_SHORT,
-            gravity: ToastGravity.BOTTOM,
-            timeInSecForIosWeb: 1,
-            backgroundColor: Colors.red,
-            textColor: Colors.white,
-            fontSize: 16.0);
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(AppLocalizations.of(context).t('personEnrolled'),
+              style: TextStyle(
+                  color: Theme.of(context).colorScheme.onErrorContainer)),
+          backgroundColor: Theme.of(context).colorScheme.errorContainer,
+          duration: const Duration(seconds: 1),
+        ));
       }
     } catch (e) {}
   }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -5,7 +5,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:settings_ui/settings_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:adaptive_theme/adaptive_theme.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'main.dart';
 import 'localization.dart';
 import 'about.dart';
@@ -112,14 +111,13 @@ class SettingsPageState extends State<SettingsPage> {
       _selectedTheme = 2;
     });
 
-    Fluttertoast.showToast(
-        msg: AppLocalizations.of(context).t('restoreDefaults'),
-        toastLength: Toast.LENGTH_SHORT,
-        gravity: ToastGravity.BOTTOM,
-        timeInSecForIosWeb: 1,
-        backgroundColor: Colors.red,
-        textColor: Colors.white,
-        fontSize: 16.0);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(AppLocalizations.of(context).t('restoreDefaults'),
+          style: TextStyle(
+              color: Theme.of(context).colorScheme.onErrorContainer)),
+      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+      duration: const Duration(seconds: 1),
+    ));
   }
 
   Future<void> updateLivenessLevel(value) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   shared_preferences: ^2.5.3
-  fluttertoast: ^8.2.12
   settings_ui: ^2.0.2
   adaptive_theme: ^3.7.0
   image_picker: ^1.1.2


### PR DESCRIPTION
## Summary
- remove `fluttertoast` dependency
- show snack bars via `ScaffoldMessenger` in `main.dart` and `settings.dart`
- use `Theme.of(context).colorScheme` for snack bar colors

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f649298488330a868d8b7d5ecf667