### PR TITLE
Fix flutter_neumorphic for Dart 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,8 @@ dependencies:
   sqflite: ^2.4.2
   logger: ^2.0.2
   intl: ^0.19.0
-  flutter_neumorphic: ^3.2.0
+  flutter_neumorphic:
+    path: third_party/flutter_neumorphic
 
 dev_dependencies:
   flutter_test:

--- a/third_party/flutter_neumorphic/pubspec.yaml
+++ b/third_party/flutter_neumorphic/pubspec.yaml
@@ -10,7 +10,7 @@ homepage: https://github.com/Idean/Flutter-Neumorphic
 issue_tracker: https://github.com/Idean/Flutter-Neumorphic/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.13.18"
 
 dependencies:


### PR DESCRIPTION
## Summary
- use local flutter_neumorphic implementation
- update dependency to support Dart 3

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f662f07948330b46a8127da6ded84