### PR TITLE
Fix intl version conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   image_picker: ^1.1.2
   sqflite: ^2.4.2
   logger: ^2.0.2
-  intl: ^0.20.2
+  intl: ^0.19.0
   flutter_neumorphic:
     path: third_party/flutter_neumorphic
 


### PR DESCRIPTION
## Summary
- align intl dependency with `flutter_localizations` by using version 0.19.0

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f83c4c35483308a1b8d9edcec5718