### PR TITLE
Fix const constructors with mutable fields

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -102,7 +102,7 @@ class FaceCaptureView extends StatefulWidget {
   FaceDetectionViewController? faceDetectionViewController;
   final Function(Person) insertPerson;
 
-  const FaceCaptureView(
+  FaceCaptureView(
       {super.key, required this.personList, required this.insertPerson});
 
   @override
@@ -633,7 +633,7 @@ class FaceCaptureDetectionView extends StatefulWidget
     implements FaceDetectionInterface {
   FaceCaptureViewState faceRecognitionViewState;
 
-  const FaceCaptureDetectionView({super.key, required this.faceRecognitionViewState});
+  FaceCaptureDetectionView({super.key, required this.faceRecognitionViewState});
 
   @override
   Future<void> onFaceDetected(faces) async {

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -18,7 +18,7 @@ class FaceRecognitionView extends StatefulWidget {
   final Function(RecognitionLog) addLog;
   FaceDetectionViewController? faceDetectionViewController;
 
-  const FaceRecognitionView({super.key, required this.personList, required this.addLog});
+  FaceRecognitionView({super.key, required this.personList, required this.addLog});
 
   @override
   State<StatefulWidget> createState() => FaceRecognitionViewState();
@@ -420,7 +420,7 @@ class FaceDetectionView extends StatefulWidget
     implements FaceDetectionInterface {
   FaceRecognitionViewState faceRecognitionViewState;
 
-  const FaceDetectionView({super.key, required this.faceRecognitionViewState});
+  FaceDetectionView({super.key, required this.faceRecognitionViewState});
 
   @override
   Future<void> onFaceDetected(faces) async {


### PR DESCRIPTION
## Summary
- remove `const` keyword from constructors that mutate fields

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f84e8918483308a2b8cc64bb37ad2