### PR TITLE
Add Neumorphic styling to log and about pages

### DIFF
--- a/lib/about.dart
+++ b/lib/about.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'localization.dart';
 
 class AboutPage extends StatelessWidget {
@@ -7,15 +8,19 @@ class AboutPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
+      appBar: NeumorphicAppBar(
         title: Text(AppLocalizations.of(context).t('aboutTitle')),
         toolbarHeight: 70,
         centerTitle: true,
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Text(AppLocalizations.of(context).t('aboutContent')),
+        child: Neumorphic(
+          margin: const EdgeInsets.all(16.0),
+          style: const NeumorphicStyle(depth: 2),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(AppLocalizations.of(context).t('aboutContent')),
+          ),
         ),
       ),
     );

--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 
@@ -15,7 +16,7 @@ class LogDetailView extends StatelessWidget {
       genderText = AppLocalizations.of(context).t('female');
     }
     return Scaffold(
-      appBar: AppBar(
+      appBar: NeumorphicAppBar(
         title: Text(AppLocalizations.of(context).t('logDetails')),
         toolbarHeight: 70,
         centerTitle: true,

--- a/lib/logview.dart
+++ b/lib/logview.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 import 'log_detail_view.dart';
@@ -10,7 +11,7 @@ class LogView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
+      appBar: NeumorphicAppBar(
         title: Text(AppLocalizations.of(context).t('logs')),
         toolbarHeight: 70,
         centerTitle: true,
@@ -18,11 +19,14 @@ class LogView extends StatelessWidget {
       body: SafeArea(
         child: logList.isEmpty
             ? Center(child: Text(AppLocalizations.of(context).t('noLogs')))
-            : ListView.builder(
-                itemCount: logList.length,
-                itemBuilder: (context, index) {
-                  final log = logList[index];
-                  return ListTile(
+            : Neumorphic(
+                margin: const EdgeInsets.all(8.0),
+                style: const NeumorphicStyle(depth: 2),
+                child: ListView.builder(
+                  itemCount: logList.length,
+                  itemBuilder: (context, index) {
+                    final log = logList[index];
+                    return ListTile(
                     title: Text(log.name),
                     subtitle: Text(log.formattedTime),
                     onTap: () {
@@ -34,7 +38,8 @@ class LogView extends StatelessWidget {
                       );
                     },
                   );
-                },
+                  },
+                ),
               ),
       ),
     );


### PR DESCRIPTION
## Summary
- import `flutter_neumorphic` package in remaining pages
- replace old `AppBar`s with `NeumorphicAppBar`
- use `Neumorphic` containers around scrollable areas for depth

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe53c6ec48330b085485e91e9dbb3