### PR TITLE
Fix intl version conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   image_picker: ^1.1.2
   sqflite: ^2.4.2
   logger: ^2.0.2
-  intl: ^0.20.2
+  intl: ^0.19.0
   flutter_neumorphic:
     path: third_party/flutter_neumorphic
 


### PR DESCRIPTION
## Summary
- downgrade `intl` dependency to `^0.19.0` to match `flutter_localizations` requirement

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fec0dddc48330b495c0056deb007b