### PR TITLE
Remove neumorphic package and switch to Material widgets

### DIFF
--- a/lib/about.dart
+++ b/lib/about.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'localization.dart';
 
 class AboutPage extends StatelessWidget {
@@ -8,14 +7,13 @@ class AboutPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: NeumorphicAppBar(
+      appBar: AppBar(
         title: Text(AppLocalizations.of(context).t('aboutTitle')),
         centerTitle: true,
       ),
       body: SafeArea(
-        child: Neumorphic(
+        child: Card(
           margin: const EdgeInsets.all(16.0),
-          style: const NeumorphicStyle(depth: 2),
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             child: Text(AppLocalizations.of(context).t('aboutContent')),

--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 
@@ -16,7 +15,7 @@ class LogDetailView extends StatelessWidget {
       genderText = AppLocalizations.of(context).t('female');
     }
     return Scaffold(
-      appBar: NeumorphicAppBar(
+      appBar: AppBar(
         title: Text(AppLocalizations.of(context).t('logDetails')),
         centerTitle: true,
       ),

--- a/lib/logview.dart
+++ b/lib/logview.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 import 'log_detail_view.dart';
@@ -11,16 +10,15 @@ class LogView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: NeumorphicAppBar(
+      appBar: AppBar(
         title: Text(AppLocalizations.of(context).t('logs')),
         centerTitle: true,
       ),
       body: SafeArea(
         child: logList.isEmpty
             ? Center(child: Text(AppLocalizations.of(context).t('noLogs')))
-            : Neumorphic(
+            : Card(
                 margin: const EdgeInsets.all(8.0),
-                style: const NeumorphicStyle(depth: 2),
                 child: ListView.builder(
                   itemCount: logList.length,
                   itemBuilder: (context, index) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,6 @@ import 'package:flutter_exif_rotation/flutter_exif_rotation.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'dart:io' show Platform;
 import 'about.dart';
 import 'settings.dart';
@@ -91,23 +90,6 @@ class _MyAppState extends State<MyApp> {
       background: const Color(0xFF141218),
     );
 
-    final neumorphicLightTheme = NeumorphicThemeData(
-      baseColor: const Color(0xFFF2F4F8),
-      accentColor: const Color(0xFFA7C7E7),
-      variantColor: const Color(0xFFE0C3FC),
-      depth: 4,
-      intensity: 0.8,
-      lightSource: LightSource.topLeft,
-    );
-
-    final neumorphicDarkTheme = NeumorphicThemeData(
-      baseColor: const Color(0xFF222532),
-      accentColor: const Color(0xFF8AA1D2),
-      variantColor: const Color(0xFF775BAE),
-      depth: 4,
-      intensity: 0.6,
-      lightSource: LightSource.topLeft,
-    );
 
     return AdaptiveTheme(
       light: ThemeData(
@@ -124,7 +106,7 @@ class _MyAppState extends State<MyApp> {
       ),
       initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
       builder: (theme, darkTheme) => Builder(
-            builder: (context) => NeumorphicApp(
+            builder: (context) => MaterialApp(
                 locale: _locale,
                 supportedLocales: AppLocalizations.supportedLocales,
                 localizationsDelegates: const [
@@ -134,10 +116,8 @@ class _MyAppState extends State<MyApp> {
                   GlobalCupertinoLocalizations.delegate,
                 ],
                 title: AppLocalizations(_locale).t('appTitle'),
-                materialTheme: theme,
-                materialDarkTheme: darkTheme,
-                theme: neumorphicLightTheme,
-                darkTheme: neumorphicDarkTheme,
+                theme: theme,
+                darkTheme: darkTheme,
                 themeMode: AdaptiveTheme.of(context).mode == AdaptiveThemeMode.dark
                     ? ThemeMode.dark
                     : AdaptiveTheme.of(context).mode == AdaptiveThemeMode.light
@@ -511,12 +491,9 @@ class MyHomePageState extends State<MyHomePage> {
         margin: const EdgeInsets.only(left: 16.0, right: 16.0),
         child: Column(
           children: <Widget>[
-            Neumorphic(
-                style: NeumorphicStyle(
-                    boxShape: NeumorphicBoxShape.roundRect(BorderRadius.circular(12)),
-                    depth: 2,
-                    shape: NeumorphicShape.flat,
-                    color: NeumorphicTheme.baseColor(context)),
+            Card(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
                 child: Padding(
                   padding: const EdgeInsets.all(12),
                   child: ListTile(
@@ -537,30 +514,23 @@ class MyHomePageState extends State<MyHomePage> {
                 mainAxisSpacing: 8,
                 childAspectRatio: 3.5,
                 children: [
-                  NeumorphicButton(
+                  FilledButton.icon(
                       onPressed: enrollPerson,
-                      style: NeumorphicStyle(
-                        color: NeumorphicTheme.accentColor(context),
-                        depth: 2,
-                        boxShape: NeumorphicBoxShape.roundRect(
-                            BorderRadius.circular(12)),
+                      style: FilledButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.primary,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.person_add,
-                              color: Theme.of(context).colorScheme.onPrimary),
-                          const SizedBox(width: 8),
-                          Text(
-                            AppLocalizations.of(context).t('enroll'),
-                            style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onPrimary),
-                          ),
-                        ],
+                      icon: Icon(Icons.person_add,
+                          color: Theme.of(context).colorScheme.onPrimary),
+                      label: Text(
+                        AppLocalizations.of(context).t('enroll'),
+                        style: TextStyle(
+                            color:
+                                Theme.of(context).colorScheme.onPrimary),
                       )),
-                  NeumorphicButton(
+                  FilledButton.icon(
                       onPressed: () {
                         Navigator.push(
                           context,
@@ -571,28 +541,21 @@ class MyHomePageState extends State<MyHomePage> {
                                   )),
                         );
                       },
-                      style: NeumorphicStyle(
-                        color: NeumorphicTheme.accentColor(context),
-                        depth: 2,
-                        boxShape: NeumorphicBoxShape.roundRect(
-                            BorderRadius.circular(12)),
+                      style: FilledButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.primary,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.person_search,
-                              color: Theme.of(context).colorScheme.onPrimary),
-                          const SizedBox(width: 8),
-                          Text(
-                            AppLocalizations.of(context).t('identify'),
-                            style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onPrimary),
-                          ),
-                        ],
+                      icon: Icon(Icons.person_search,
+                          color: Theme.of(context).colorScheme.onPrimary),
+                      label: Text(
+                        AppLocalizations.of(context).t('identify'),
+                        style: TextStyle(
+                            color:
+                                Theme.of(context).colorScheme.onPrimary),
                       )),
-                  NeumorphicButton(
+                  FilledButton.icon(
                       onPressed: () {
                         Navigator.push(
                           context,
@@ -602,28 +565,20 @@ class MyHomePageState extends State<MyHomePage> {
                                   )),
                         );
                       },
-                      style: NeumorphicStyle(
-                        color: NeumorphicTheme.accentColor(context),
-                        depth: 2,
-                        boxShape: NeumorphicBoxShape.roundRect(
-                            BorderRadius.circular(12)),
+                      style: FilledButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.primary,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.settings,
-                              color: Theme.of(context).colorScheme.onPrimary),
-                          const SizedBox(width: 8),
-                          Text(
-                            AppLocalizations.of(context).t('settings'),
-                            style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onPrimary),
-                          ),
-                        ],
+                      icon: Icon(Icons.settings,
+                          color: Theme.of(context).colorScheme.onPrimary),
+                      label: Text(
+                        AppLocalizations.of(context).t('settings'),
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimary),
                       )),
-                  NeumorphicButton(
+                  FilledButton.icon(
                       onPressed: () {
                         Navigator.push(
                           context,
@@ -634,28 +589,20 @@ class MyHomePageState extends State<MyHomePage> {
                                   )),
                         );
                       },
-                      style: NeumorphicStyle(
-                        color: NeumorphicTheme.accentColor(context),
-                        depth: 2,
-                        boxShape: NeumorphicBoxShape.roundRect(
-                            BorderRadius.circular(12)),
+                      style: FilledButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.primary,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.person_pin,
-                              color: Theme.of(context).colorScheme.onPrimary),
-                          const SizedBox(width: 8),
-                          Text(
-                            AppLocalizations.of(context).t('capture'),
-                            style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onPrimary),
-                          ),
-                        ],
+                      icon: Icon(Icons.person_pin,
+                          color: Theme.of(context).colorScheme.onPrimary),
+                      label: Text(
+                        AppLocalizations.of(context).t('capture'),
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimary),
                       )),
-                  NeumorphicButton(
+                  FilledButton.icon(
                       onPressed: () {
                         Navigator.push(
                           context,
@@ -665,26 +612,18 @@ class MyHomePageState extends State<MyHomePage> {
                                   )),
                         );
                       },
-                      style: NeumorphicStyle(
-                        color: NeumorphicTheme.accentColor(context),
-                        depth: 2,
-                        boxShape: NeumorphicBoxShape.roundRect(
-                            BorderRadius.circular(12)),
+                      style: FilledButton.styleFrom(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.primary,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.list,
-                              color: Theme.of(context).colorScheme.onPrimary),
-                          const SizedBox(width: 8),
-                          Text(
-                            AppLocalizations.of(context).t('logs'),
-                            style: TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onPrimary),
-                          ),
-                        ],
+                      icon: Icon(Icons.list,
+                          color: Theme.of(context).colorScheme.onPrimary),
+                      label: Text(
+                        AppLocalizations.of(context).t('logs'),
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimary),
                       )),
                 ],
               ),

--- a/lib/personview.dart
+++ b/lib/personview.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import 'person.dart';
 import 'main.dart';
 
@@ -31,13 +30,10 @@ class _PersonViewState extends State<PersonView> {
     return ListView.builder(
         itemCount: widget.personList.length,
         itemBuilder: (BuildContext context, int index) {
-          return Neumorphic(
+          return Card(
             margin: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
-            style: NeumorphicStyle(
-              depth: 2,
-              boxShape: NeumorphicBoxShape.roundRect(
-                const BorderRadius.all(Radius.circular(12)),
-              ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
             ),
             child: ListTile(
               leading: ClipRRect(
@@ -48,20 +44,19 @@ class _PersonViewState extends State<PersonView> {
                   height: 56,
                 ),
               ),
-              title: NeumorphicText(
+              title: Text(
                 widget.personList[index].name,
-                style: const NeumorphicStyle(depth: 1),
-                textStyle: NeumorphicTextStyle(fontSize: 16),
+                style: const TextStyle(fontSize: 16),
               ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   IconButton(
-                    icon: NeumorphicIcon(Icons.edit, size: 24),
+                    icon: const Icon(Icons.edit, size: 24),
                     onPressed: () => renamePerson(index),
                   ),
                   IconButton(
-                    icon: NeumorphicIcon(Icons.delete, size: 24),
+                    icon: const Icon(Icons.delete, size: 24),
                     onPressed: () => deletePerson(index),
                   ),
                 ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,8 +47,6 @@ dependencies:
   sqflite: ^2.4.2
   logger: ^2.0.2
   intl: ^0.19.0
-  flutter_neumorphic:
-    path: third_party/flutter_neumorphic
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace `NeumorphicApp` with `MaterialApp`
- swap neumorphic buttons for `FilledButton.icon`
- use a `Card` above the grid
- remove `flutter_neumorphic` import from supporting pages
- update `pubspec.yaml` to drop dependency

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fef93a4c083308f131eee49096c21