### PR TITLE
Refactor log and person views to use Material cards

### DIFF
--- a/lib/about.dart
+++ b/lib/about.dart
@@ -13,6 +13,7 @@ class AboutPage extends StatelessWidget {
       ),
       body: SafeArea(
         child: Card(
+          color: Theme.of(context).colorScheme.surfaceVariant,
           margin: const EdgeInsets.all(16.0),
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),

--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -20,25 +20,29 @@ class LogDetailView extends StatelessWidget {
         centerTitle: true,
       ),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('${AppLocalizations.of(context).t('name')}${log.name}'),
-              const SizedBox(height: 8),
-              Text('${AppLocalizations.of(context).t('time')}${log.formattedTime}'),
-              const SizedBox(height: 8),
-              if (log.age >= 0) ...[
-                Text('${AppLocalizations.of(context).t('age')}${log.age}'),
+        child: Card(
+          color: Theme.of(context).colorScheme.surfaceVariant,
+          margin: const EdgeInsets.all(16.0),
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('${AppLocalizations.of(context).t('name')}${log.name}'),
                 const SizedBox(height: 8),
+                Text('${AppLocalizations.of(context).t('time')}${log.formattedTime}'),
+                const SizedBox(height: 8),
+                if (log.age >= 0) ...[
+                  Text('${AppLocalizations.of(context).t('age')}${log.age}'),
+                  const SizedBox(height: 8),
+                ],
+                if (log.gender >= 0)
+                  Text('${AppLocalizations.of(context).t('gender')}$genderText'),
               ],
-              if (log.gender >= 0)
-                Text('${AppLocalizations.of(context).t('gender')}$genderText'),
-            ],
           ),
         ),
       ),
+    );
     );
   }
 }

--- a/lib/logview.dart
+++ b/lib/logview.dart
@@ -18,6 +18,7 @@ class LogView extends StatelessWidget {
         child: logList.isEmpty
             ? Center(child: Text(AppLocalizations.of(context).t('noLogs')))
             : Card(
+                color: Theme.of(context).colorScheme.surfaceVariant,
                 margin: const EdgeInsets.all(8.0),
                 child: ListView.builder(
                   itemCount: logList.length,

--- a/lib/personview.dart
+++ b/lib/personview.dart
@@ -31,6 +31,7 @@ class _PersonViewState extends State<PersonView> {
         itemCount: widget.personList.length,
         itemBuilder: (BuildContext context, int index) {
           return Card(
+            color: Theme.of(context).colorScheme.surfaceVariant,
             margin: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),


### PR DESCRIPTION
## Summary
- switch old Neumorphic containers to `Card` widgets with `surfaceVariant` colors
- keep regular `AppBar` in each page
- wrap `ListTile` entries in `PersonView` with colored cards

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff0f153dc833086ba35536df42c18