### PR TITLE
Fix log detail widget syntax

### DIFF
--- a/lib/log_detail_view.dart
+++ b/lib/log_detail_view.dart
@@ -59,7 +59,6 @@ class LogDetailView extends StatelessWidget {
           ),
         ),
       ),
-    ),
   );
   }
 }


### PR DESCRIPTION
## Summary
- fix unmatched closing parenthesis in `LogDetailView`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686018977fa08330a02471b9bc86acc1