### PR TITLE
Handle icons without embedding binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Launcher icon source
+assets/app_icon.png

--- a/README.md
+++ b/README.md
@@ -184,4 +184,15 @@ This project now supports light and dark themes using the `adaptive_theme` packa
 
 ### BLE Relay Example
 The app demonstrates how to trigger a BLE relay when a face is successfully recognized. A `RelayService` class uses the `flutter_blue_plus` plugin to connect to modules like **BT37E04** and sends the command `A0 [relay] [state] [checksum]`.
+
+### Generating App Icons
+This project uses the [`flutter_launcher_icons` package](https://pub.dev/packages/flutter_launcher_icons) to build launcher icons for all supported platforms from a single image.
+
+1. Place your icon image at `assets/app_icon.png` (this file is not stored in the repository).
+2. Run the following commands:
+   ```bash
+   flutter pub get
+   flutter pub run flutter_launcher_icons
+   ```
+   Generated icons will be placed into each platform's resources.
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^4.0.0
+  flutter_launcher_icons: ^0.14.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -73,6 +74,8 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    # User-provided icon; add this file locally when generating launcher icons.
+    - assets/app_icon.png
     - assets/ic_kby.png
     - assets/ic_skype.png
     - assets/ic_telegram.png
@@ -111,3 +114,13 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+flutter_launcher_icons:
+  android: true
+  ios: true
+  macos:
+    generate: true
+  windows:
+    generate: true
+  image_path: assets/app_icon.png
+  min_sdk_android: 21


### PR DESCRIPTION
## Summary
- remove `assets/app_icon.png` binary from version control
- document that the launcher icon image must be supplied locally
- add comment in `pubspec.yaml` about user-provided icon
- ignore `assets/app_icon.png` in `.gitignore`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686155be73f88330ad2180df885505cd