### PR TITLE
Add BLE broadcast for offline notifications

### DIFF
--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+class BleNotificationService {
+  BleNotificationService._internal();
+  static final BleNotificationService instance = BleNotificationService._internal();
+
+  final FlutterBlePeripheral _peripheral = FlutterBlePeripheral();
+  StreamSubscription<List<ScanResult>>? _scanSubscription;
+  final StreamController<String> _messages = StreamController<String>.broadcast();
+
+  Stream<String> get messages => _messages.stream;
+
+  Future<void> startScanning() async {
+    await _scanSubscription?.cancel();
+    _scanSubscription = FlutterBluePlus.scanResults.listen((results) {
+      for (final r in results) {
+        if (r.advertisementData.manufacturerData.isNotEmpty) {
+          final bytes = r.advertisementData.manufacturerData.values.first;
+          try {
+            final msg = String.fromCharCodes(bytes);
+            _messages.add(msg);
+          } catch (_) {}
+        } else if (r.advertisementData.advName.startsWith('face:')) {
+          _messages.add(r.advertisementData.advName.substring(5));
+        }
+      }
+    });
+    await FlutterBluePlus.startScan(timeout: const Duration(seconds: 0));
+  }
+
+  Future<void> stopScanning() async {
+    await FlutterBluePlus.stopScan();
+    await _scanSubscription?.cancel();
+    _scanSubscription = null;
+  }
+
+  Future<void> broadcastName(String name, {Duration duration = const Duration(seconds: 5)}) async {
+    final data = AdvertiseData(
+      includeDeviceName: true,
+      localName: 'face:$name',
+      manufacturerId: 0xffff,
+      manufacturerData: Uint8List.fromList(name.codeUnits),
+    );
+    await _peripheral.start(advertiseData: data);
+    await Future.delayed(duration);
+    await _peripheral.stop();
+  }
+}

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -12,6 +12,7 @@ import 'person.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 import 'relay_service.dart';
+import 'ble_notification_service.dart';
 
 // ignore: must_be_immutable
 class FaceRecognitionView extends StatefulWidget {
@@ -169,6 +170,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
             age: _estimateAgeGender ? maxAge : -1,
             gender: _estimateAgeGender ? maxGender : -1));
         unawaited(_relayService.sendRelay(1, true));
+        unawaited(BleNotificationService.instance.broadcastName(maxSimilarityName));
         faceDetectionViewController?.stopCamera();
         setState(() {
           _faces = null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -635,7 +635,9 @@ class MyHomePageState extends State<MyHomePage> {
                         style: TextStyle(
                             color: Theme.of(context).colorScheme.onPrimary),
                       )),
-                ],
+                    ],
+                  );
+                },
               ),
             ),
             const SizedBox(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'personview.dart';
 import 'facedetectionview.dart';
 import 'facecaptureview.dart';
 import 'logview.dart';
+import 'ble_notification_service.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
 
@@ -153,6 +154,13 @@ class MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
+    BleNotificationService.instance.startScanning();
+    BleNotificationService.instance.messages.listen((name) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$name yüzü okundu')),
+      );
+    });
     // Delay heavy initialization until after the first frame so that
     // the UI can render without blocking on native plugin calls.
     WidgetsBinding.instance.addPostFrameCallback((_) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   logger: ^2.0.2
   intl: ^0.19.0
   flutter_blue_plus: ^1.16.7
+  flutter_ble_peripheral: ^1.2.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `flutter_ble_peripheral` package for BLE advertising
- implement `BleNotificationService` to broadcast recognized names via BLE and listen for messages
- broadcast BLE notification when a face is recognized
- show a snackbar when another device broadcasts a recognition event

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686179905ac883308fca4c535b9546ce