### PR TITLE
Fix BLE scanning permission for notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <application
         android:label="Luna Yüz Tanıma"

--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -29,7 +29,10 @@ class BleNotificationService {
         }
       }
     });
-    await FlutterBluePlus.startScan(timeout: const Duration(seconds: 0));
+    await FlutterBluePlus.startScan(
+      timeout: const Duration(seconds: 0),
+      androidUsesFineLocation: true,
+    );
   }
 
   Future<void> stopScanning() async {


### PR DESCRIPTION
## Summary
- enable location permission for BLE scanning
- request fine location use when scanning

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618d72373c8330ba5abafd0e60904a