### PR TITLE
Fix portrait orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ To run this repo successfully, license should be required based on each `applica
   flutter clean
   flutter pub get
   flutter run
-  ```  
+  ```
+  The Android build now locks the interface to portrait orientation to prevent
+  layout issues when holding the device vertically.
   If you plan to run the iOS app, please refer to the following [link](https://docs.flutter.dev/deployment/ios) for detailed instructions.</br>
 ## About SDK
 ### 1. Setup

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
## Summary
- restrict Android build to portrait mode
- document the portrait orientation requirement in the README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686195a3da688330ba50569e18745d00