### PR TITLE
Fix orientation handling

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -445,7 +445,8 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
         ),
         body: SafeArea(
           child: OrientationBuilder(builder: (context, orientation) {
-            final quarterTurns = orientation == Orientation.portrait ? 1 : 0;
+            // Remove rotation to properly handle both orientations
+            const quarterTurns = 0;
             return Stack(
             children: <Widget>[
               RotatedBox(

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -198,7 +198,8 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
         ),
         body: SafeArea(
           child: OrientationBuilder(builder: (context, orientation) {
-            final quarterTurns = orientation == Orientation.portrait ? 1 : 0;
+            // Remove rotation to support both portrait and landscape properly
+            const quarterTurns = 0;
             return Stack(children: <Widget>[
               RotatedBox(
                 quarterTurns: quarterTurns,


### PR DESCRIPTION
## Summary
- remove RotatedBox quarterTurns to avoid portrait mode rotation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619edcc16083309e69f53348b57cb2