### PR TITLE
Fix camera rotation for portrait mode

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -445,7 +445,7 @@ class FaceCaptureViewState extends State<FaceCaptureView> {
         ),
         body: SafeArea(
           child: OrientationBuilder(builder: (context, orientation) {
-            final quarterTurns = orientation == Orientation.portrait ? 1 : 0;
+            final quarterTurns = orientation == Orientation.landscape ? 1 : 0;
             return Stack(
             children: <Widget>[
               RotatedBox(

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -198,7 +198,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
         ),
         body: SafeArea(
           child: OrientationBuilder(builder: (context, orientation) {
-            final quarterTurns = orientation == Orientation.portrait ? 1 : 0;
+            final quarterTurns = orientation == Orientation.landscape ? 1 : 0;
             return Stack(children: <Widget>[
               RotatedBox(
                 quarterTurns: quarterTurns,


### PR DESCRIPTION
## Summary
- fix orientation detection so portrait mode no longer rotates camera preview

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621c51f91483309f83ef6c72e8e467