### PR TITLE
Adjust button style and grid layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ class _MyAppState extends State<MyApp> {
     );
     final buttonTheme = FilledButtonThemeData(
       style: FilledButton.styleFrom(
-        padding: const EdgeInsets.symmetric(vertical: 12),
+        padding: const EdgeInsets.symmetric(vertical: 8),
         shape: const StadiumBorder(),
       ),
     );
@@ -625,16 +625,14 @@ class MyHomePageState extends State<MyHomePage> {
             Expanded(
               child: Builder(
                 builder: (context) {
-                  final orientation = MediaQuery.of(context).orientation;
                   final actions = _buildActionButtons();
                   return GridView.builder(
                     itemCount: actions.length,
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount:
-                          orientation == Orientation.portrait ? 2 : 4,
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
                       crossAxisSpacing: 12,
                       mainAxisSpacing: 8,
-                      childAspectRatio: 3.0,
+                      childAspectRatio: 4.0,
                     ),
                     itemBuilder: (context, index) => actions[index],
                   );


### PR DESCRIPTION
## Summary
- reduce vertical padding for filled buttons to 8
- simplify `GridView.builder` to always show two columns with a shorter height

## Testing
- `flutter analyze` *(failed: `/tmp/flutter/bin/internal/shared.sh: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6862247e57a483308c2fbe519751542e