### PR TITLE
Adjust info box in landscape

### DIFF
--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -217,10 +217,16 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
               ),
             Visibility(
                 visible: _recognized,
-                child: Container(
-                  width: double.infinity,
-                  height: double.infinity,
-                  color: Theme.of(context).colorScheme.background,
+                child: Align(
+                  alignment: orientation == Orientation.landscape
+                      ? Alignment.centerRight
+                      : Alignment.topCenter,
+                  child: Container(
+                    width: orientation == Orientation.landscape
+                        ? MediaQuery.of(context).size.width * 0.6
+                        : double.infinity,
+                    height: double.infinity,
+                    color: Theme.of(context).colorScheme.background,
                   child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -426,7 +426,7 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
                           child: Text(AppLocalizations.of(context).t('tryAgain')),
                         ),
                       ]),
-                )),
+                ))),
               ]);
             }),
           ),


### PR DESCRIPTION
## Summary
- keep recognition info box full width in portrait
- in landscape, align the info box to the right and use 60% of screen width

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622fedb6a88330a36d36874bc1558a