### PR TITLE
Add location permission for BLE scanning

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:label="Luna Yüz Tanıma"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- include fine location permission for BLE scanning

## Testing
- `gradle -p android assembleDebug` *(fails: `/workspace/FaceAttribute-Flutter/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_6862c12ea02c83308b749d3dd8f7e8aa