### PR TITLE
Fix Person class import conflict

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,8 @@ import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'dart:async';
 import 'facesdk_plugin_import.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart'
+    hide Person;
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_exif_rotation/flutter_exif_rotation.dart';
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
## Summary
- avoid naming conflict between packages by hiding `Person` from `flutter_local_notifications`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb87b3b48330af8380a15eb043af