### PR TITLE
Fix build by enabling desugaring

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,6 +33,8 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_21  // Changed from 1_8 to 21
         targetCompatibility JavaVersion.VERSION_21
+        // Enable core library desugaring for Java 21 APIs
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -71,4 +73,6 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    // Required library for core library desugaring
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring in Android build
- include desugar_jdk_libs dependency

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862cd11651c833086300bea3b1cbed6