### PR TITLE
Fix Android build error with JDK 21

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update Gradle wrapper properties to use Gradle 8.5

## Testing
- `dart format --output=none --set-exit-if-changed \
  $(git ls-files '*.dart')` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d00a1e4c8330b936ec66a37f633c