### PR TITLE
Fix Jetifier failure

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,15 @@ allprojects {
         google()
         mavenCentral()
     }
+
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.bouncycastle' &&
+                    details.requested.name == 'bcprov-jdk18on') {
+                details.useVersion '1.77'
+            }
+        }
+    }
 }
 
 rootProject.buildDir = '../build'


### PR DESCRIPTION
## Summary
- pin `bcprov-jdk18on` to 1.77 so Jetifier can handle the jar

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862d26a45a88330b324507df13412e3