### PR TITLE
Add notification permission flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ To run this repo successfully, license should be required based on each `applica
   flutter clean
   flutter pub get
   flutter run
-  ```  
+  ```
+  On Android devices running version 13 or higher, make sure to grant the
+  **Post Notifications** permission when prompted on first launch.
   If you plan to run the iOS app, please refer to the following [link](https://docs.flutter.dev/deployment/ios) for detailed instructions.</br>
 ## About SDK
 ### 1. Setup

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="Luna Yüz Tanıma"
         android:name="${applicationName}"

--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -24,6 +24,7 @@ class BleNotificationService {
       Permission.bluetoothAdvertise,
       Permission.bluetoothConnect,
       Permission.locationWhenInUse,
+      Permission.notification,
     ].request();
     statuses.forEach((permission, status) {
       if (status.isGranted) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'logview.dart';
 import 'ble_notification_service.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
@@ -170,12 +171,18 @@ class MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
     BleNotificationService.instance.startScanning();
-    BleNotificationService.instance.messages.listen((name) {
+    BleNotificationService.instance.messages.listen((name) async {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('$name yüzü okundu')),
       );
-      _showNotification(name);
+      var status = await Permission.notification.status;
+      if (!status.isGranted) {
+        status = await Permission.notification.request();
+      }
+      if (status.isGranted) {
+        _showNotification(name);
+      }
     });
     // Delay heavy initialization until after the first frame so that
     // the UI can render without blocking on native plugin calls.


### PR DESCRIPTION
## Summary
- request POST_NOTIFICATIONS permission in AndroidManifest
- ask for notification permission when requesting BLE permissions
- ensure notifications are only shown if permission is granted
- document the new notification permission requirement

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e741a68c8330a72cd2482a30d500