### PR TITLE
Pause BLE scan while sending relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ This project now supports light and dark themes using the `adaptive_theme` packa
 
 ### BLE Relay Example
 The app demonstrates how to trigger a BLE relay when a face is successfully recognized. A `RelayService` class uses the `flutter_blue_plus` plugin to connect to modules like **BT37E04** and sends the command `A0 [relay] [state] [checksum]`.
+While the relay command is being sent, BLE notification scanning is temporarily paused and restarted afterwards.
 
 ### Generating App Icons
 This project uses the [`flutter_launcher_icons` package](https://pub.dev/packages/flutter_launcher_icons) to build launcher icons for all supported platforms from a single image.

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -144,8 +144,8 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
       }
     }
 
-    Future.delayed(const Duration(milliseconds: 100), () {
-      if (!mounted) return false;
+    Future.delayed(const Duration(milliseconds: 100), () async {
+      if (!mounted) return;
       setState(() {
         _recognized = recognized;
         _identifiedName = maxSimilarityName;
@@ -169,7 +169,14 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
             time: DateTime.now().toIso8601String(),
             age: _estimateAgeGender ? maxAge : -1,
             gender: _estimateAgeGender ? maxGender : -1));
-        unawaited(_relayService.sendRelay(1, true));
+        await BleNotificationService.instance.stopScanning();
+        try {
+          await _relayService.sendRelay(1, true);
+        } catch (e, st) {
+          AppLogger.e('Failed to send relay', e, st);
+        } finally {
+          await BleNotificationService.instance.startScanning();
+        }
         unawaited(BleNotificationService.instance.broadcastName(maxSimilarityName));
         faceDetectionViewController?.stopCamera();
         setState(() {


### PR DESCRIPTION
## Summary
- pause notification scanning before sending BLE relay
- restart scanning after the relay command finishes
- log relay failures
- document scan pause behaviour in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9a84c3c83308831ede22491996b