### PR TITLE
Update BLE advertising flow

### DIFF
--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -86,10 +86,19 @@ class BleNotificationService {
       manufacturerId: 0xffff,
       manufacturerData: Uint8List.fromList(name.codeUnits),
     );
-    await _peripheral.start(advertiseData: data);
-    AppLogger.i('BLE advertising started');
+    try {
+      await _peripheral.start(advertiseData: data);
+      AppLogger.i('BLE advertising started');
+    } catch (e, st) {
+      AppLogger.e('Failed to start BLE advertising', e, st);
+      return;
+    }
     await Future.delayed(duration);
-    await _peripheral.stop();
-    AppLogger.i('BLE advertising stopped');
+    try {
+      await _peripheral.stop();
+      AppLogger.i('BLE advertising stopped');
+    } catch (e, st) {
+      AppLogger.e('Failed to stop BLE advertising', e, st);
+    }
   }
 }

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -174,10 +174,9 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
           await _relayService.sendRelay(1, true);
         } catch (e, st) {
           AppLogger.e('Failed to send relay', e, st);
-        } finally {
-          await BleNotificationService.instance.startScanning();
         }
-        unawaited(BleNotificationService.instance.broadcastName(maxSimilarityName));
+        await BleNotificationService.instance.broadcastName(maxSimilarityName);
+        await BleNotificationService.instance.startScanning();
         faceDetectionViewController?.stopCamera();
         setState(() {
           _faces = null;


### PR DESCRIPTION
## Summary
- log BLE advertising start/stop errors via AppLogger
- advertise name before restarting scanning after recognition

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862ebb977c083309297c0761969df8f