### PR TITLE
Enable BLE scanning in background

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <application
         android:label="Luna Yüz Tanıma"
         android:name="${applicationName}"
@@ -32,6 +34,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:name="id.flutter.flutter_background_service.BackgroundService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_background_service/flutter_background_service_android.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'ble_notification_service.dart';
+
+const String notificationChannelId = 'ble_scan';
+const int notificationId = 999;
+
+Future<void> initializeBleForegroundService() async {
+  final service = FlutterBackgroundService();
+
+  const AndroidNotificationChannel channel = AndroidNotificationChannel(
+    notificationChannelId,
+    'BLE Scan',
+    description: 'Scanning for BLE messages',
+    importance: Importance.low,
+  );
+
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  await flutterLocalNotificationsPlugin
+      .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>()
+      ?.createNotificationChannel(channel);
+
+  await service.configure(
+    androidConfiguration: AndroidConfiguration(
+      onStart: bleServiceOnStart,
+      autoStart: true,
+      isForegroundMode: true,
+      notificationChannelId: notificationChannelId,
+      initialNotificationTitle: 'BLE Scanning',
+      initialNotificationContent: 'Listening for BLE messages',
+      foregroundServiceNotificationId: notificationId,
+      foregroundServiceTypes: [AndroidForegroundType.connectedDevice],
+    ),
+    iosConfiguration: const IosConfiguration(),
+  );
+}
+
+@pragma('vm:entry-point')
+void bleServiceOnStart(ServiceInstance service) async {
+  DartPluginRegistrant.ensureInitialized();
+
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  BleNotificationService.instance.messages.listen((msg) {
+    flutterLocalNotificationsPlugin.show(
+      msg.hashCode,
+      'BLE Message',
+      msg,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          notificationChannelId,
+          'BLE Scan',
+          importance: Importance.defaultImportance,
+          icon: '@mipmap/ic_launcher',
+        ),
+      ),
+    );
+  });
+
+  await BleNotificationService.instance.startScanning();
+
+  service.on('stopService').listen((event) async {
+    await BleNotificationService.instance.stopScanning();
+    service.stopSelf();
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'logview.dart';
 import 'ble_notification_service.dart';
 import 'recognition_log.dart';
 import 'localization.dart';
+import 'ble_foreground_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
@@ -30,6 +31,7 @@ final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeBleForegroundService();
   AdaptiveThemeMode? savedThemeMode;
   try {
     savedThemeMode = await AdaptiveTheme.getThemeMode();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flutter_ble_peripheral: ^1.2.6
   permission_handler: ^12.0.0
   flutter_local_notifications: ^19.3.0
+  flutter_background_service: ^5.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- keep BLE scanning alive with flutter_background_service
- set up background service during app startup
- declare foreground service and permissions in Android manifest

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ef94264083308bfa81d2207a7842