### PR TITLE
Fix background service setup

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter_background_service/flutter_background_service.dart';
-import 'package:flutter_background_service/flutter_background_service_android.dart';
+import 'package:flutter_background_service_android/flutter_background_service_android.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'ble_notification_service.dart';
 
@@ -36,7 +36,7 @@ Future<void> initializeBleForegroundService() async {
       foregroundServiceNotificationId: notificationId,
       foregroundServiceTypes: [AndroidForegroundType.connectedDevice],
     ),
-    iosConfiguration: const IosConfiguration(),
+    iosConfiguration: IosConfiguration(),
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
   permission_handler: ^12.0.0
   flutter_local_notifications: ^19.3.0
   flutter_background_service: ^5.1.0
+  flutter_background_service_android: ^6.3.0
+  flutter_background_service_ios: ^5.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update Android service import
- remove `const` from `IosConfiguration`
- add missing flutter_background_service platform packages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862f1e7295483308d1b4f6bba60c58a