### PR TITLE
Fix missing DartPluginRegistrant import

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 import 'package:flutter_background_service/flutter_background_service.dart';
 import 'package:flutter_background_service_android/flutter_background_service_android.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';


### PR DESCRIPTION
## Summary
- add `dart:ui` import to use `DartPluginRegistrant`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862f3bdab2483308ddca25d602cdc0a