### PR TITLE
Fix BLE foreground service and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This project now supports light and dark themes using the `adaptive_theme` packa
 ### BLE Relay Example
 The app demonstrates how to trigger a BLE relay when a face is successfully recognized. A `RelayService` class uses the `flutter_blue_plus` plugin to connect to modules like **BT37E04** and sends the command `A0 [relay] [state] [checksum]`.
 While the relay command is being sent, BLE notification scanning is temporarily paused and restarted afterwards.
+To ensure scanning continues reliably on Android 12 and higher, a foreground service is started automatically at app launch.
 
 ### Generating App Icons
 This project uses the [`flutter_launcher_icons` package](https://pub.dev/packages/flutter_launcher_icons) to build launcher icons for all supported platforms from a single image.

--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -39,6 +39,10 @@ Future<void> initializeBleForegroundService() async {
     ),
     iosConfiguration: IosConfiguration(),
   );
+
+  // Ensure the service actually starts. Without this call the background
+  // service might never begin, preventing BLE scanning and notifications.
+  await service.startService();
 }
 
 @pragma('vm:entry-point')


### PR DESCRIPTION
## Summary
- start the BLE foreground service so background scanning begins
- clarify in the README that a foreground service handles BLE scanning

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5fc97208330988efdd668b0bb45