### PR TITLE
Fix BLE notifications between devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This project now supports light and dark themes using the `adaptive_theme` packa
 ### BLE Relay Example
 The app demonstrates how to trigger a BLE relay when a face is successfully recognized. A `RelayService` class uses the `flutter_blue_plus` plugin to connect to modules like **BT37E04** and sends the command `A0 [relay] [state] [checksum]`.
 While the relay command is being sent, BLE notification scanning is temporarily paused and restarted afterwards.
-To ensure scanning continues reliably on Android 12 and higher, a foreground service is started automatically at app launch.
+To ensure scanning continues reliably on Android 12 and higher, a foreground service is started automatically at app launch. The scanning logic also automatically restarts if the system stops it unexpectedly.
 
 ### Generating App Icons
 This project uses the [`flutter_launcher_icons` package](https://pub.dev/packages/flutter_launcher_icons) to build launcher icons for all supported platforms from a single image.

--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -15,6 +15,7 @@ class BleNotificationService {
 
   final FlutterBlePeripheral _peripheral = FlutterBlePeripheral();
   StreamSubscription<List<ScanResult>>? _scanSubscription;
+  StreamSubscription<bool>? _scanStateSubscription;
   final StreamController<String> _messages = StreamController<String>.broadcast();
 
   Stream<String> get messages => _messages.stream;
@@ -79,6 +80,7 @@ class BleNotificationService {
     }
     AppLogger.i('Starting BLE scan');
     await _scanSubscription?.cancel();
+    await _scanStateSubscription?.cancel();
     _scanSubscription = FlutterBluePlus.scanResults.listen((results) {
       for (final r in results) {
         if (r.advertisementData.manufacturerData.isNotEmpty) {
@@ -96,6 +98,13 @@ class BleNotificationService {
       }
     });
     await FlutterBluePlus.startScan(timeout: const Duration(seconds: 0));
+    _scanStateSubscription =
+        FlutterBluePlus.isScanning.listen((isScanning) async {
+      if (!isScanning) {
+        AppLogger.i('Scan stopped unexpectedly, restarting');
+        await FlutterBluePlus.startScan(timeout: const Duration(seconds: 0));
+      }
+    });
     AppLogger.i('BLE scan started');
   }
 
@@ -103,6 +112,8 @@ class BleNotificationService {
     await FlutterBluePlus.stopScan();
     await _scanSubscription?.cancel();
     _scanSubscription = null;
+    await _scanStateSubscription?.cancel();
+    _scanStateSubscription = null;
     AppLogger.i('Stopped BLE scan');
   }
 


### PR DESCRIPTION
## Summary
- add auto-restart of BLE scanning
- document that scanning restarts automatically

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f90d4d3c8330a9393b71a6d9b218