### PR TITLE
Fix BLE scan notification on Android 13+

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,13 @@ final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await initializeBleForegroundService();
+  var notificationStatus = await Permission.notification.status;
+  if (!notificationStatus.isGranted) {
+    notificationStatus = await Permission.notification.request();
+  }
+  if (notificationStatus.isGranted) {
+    await initializeBleForegroundService();
+  }
   AdaptiveThemeMode? savedThemeMode;
   try {
     savedThemeMode = await AdaptiveTheme.getThemeMode();


### PR DESCRIPTION
## Summary
- request notification permission before initializing BLE foreground service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862fcd08d28833092b89e6eeb8badcc