### PR TITLE
Add foreground service permission for BLE on Android 14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ To run this repo successfully, license should be required based on each `applica
   On Android devices running version 12 or higher, make sure to grant the
   **Nearby devices** and **Post Notifications** permissions when prompted.
   BLE features also require **Location** permission and that location services
-  are enabled on the device.
+  are enabled on the device. On Android 14 and above you must also grant the
+  **Foreground service (connected device)** permission when requested.
   If you plan to run the iOS app, please refer to the following [link](https://docs.flutter.dev/deployment/ios) for detailed instructions.</br>
 ## About SDK
 ### 1. Setup
@@ -190,6 +191,7 @@ This project now supports light and dark themes using the `adaptive_theme` packa
 The app demonstrates how to trigger a BLE relay when a face is successfully recognized. A `RelayService` class uses the `flutter_blue_plus` plugin to connect to modules like **BT37E04** and sends the command `A0 [relay] [state] [checksum]`.
 While the relay command is being sent, BLE notification scanning is temporarily paused and restarted afterwards.
 To ensure scanning continues reliably on Android 12 and higher, a foreground service is started automatically at app launch. The scanning logic also automatically restarts if the system stops it unexpectedly.
+Android 14+ additionally requires granting the **Foreground service (connected device)** permission to keep scanning in the background.
 
 ### Generating App Icons
 This project uses the [`flutter_launcher_icons` package](https://pub.dev/packages/flutter_launcher_icons) to build launcher icons for all supported platforms from a single image.

--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -6,6 +6,13 @@ import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'dart:io' show Platform;
+
+int _androidSdkInt() {
+  if (!Platform.isAndroid) return 0;
+  final match = RegExp(r'API (\d+)').firstMatch(Platform.operatingSystemVersion);
+  return match != null ? int.tryParse(match.group(1) ?? '') ?? 0 : 0;
+}
 
 import 'logger.dart';
 
@@ -22,13 +29,17 @@ class BleNotificationService {
 
   Future<bool> _requestPermissions(BuildContext? context) async {
     AppLogger.i('Requesting BLE permissions');
-    final statuses = await [
+    final permissions = [
       Permission.bluetoothScan,
       Permission.bluetoothAdvertise,
       Permission.bluetoothConnect,
       Permission.locationWhenInUse,
       Permission.notification,
-    ].request();
+    ];
+    if (Platform.isAndroid && _androidSdkInt() >= 34) {
+      permissions.add(Permission.foregroundService);
+    }
+    final statuses = await permissions.request();
 
     statuses.forEach((permission, status) {
       if (status.isGranted) {
@@ -41,7 +52,13 @@ class BleNotificationService {
     final granted = statuses.values.every((status) => status.isGranted);
     if (!granted) {
       AppLogger.e(
-          'Required BLE permissions not granted. Please grant "Nearby devices" and "Post notifications" permissions in system settings.');
+          'Required BLE permissions not granted. Please grant "Nearby devices", "Post notifications" and "Foreground service (connected device)" permissions in system settings.');
+    }
+    if (Platform.isAndroid && _androidSdkInt() >= 34) {
+      final fgStatus = statuses[Permission.foregroundService];
+      if (!(fgStatus?.isGranted ?? false)) {
+        AppLogger.e('Foreground service permission denied');
+      }
     }
 
     bool locationEnabled = true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,12 @@ import 'localization.dart';
 import 'ble_foreground_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+int _androidSdkInt() {
+  if (!Platform.isAndroid) return 0;
+  final match = RegExp(r'API (\d+)').firstMatch(Platform.operatingSystemVersion);
+  return match != null ? int.tryParse(match.group(1) ?? '') ?? 0 : 0;
+}
+
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
 
@@ -35,7 +41,14 @@ Future<void> main() async {
   if (!notificationStatus.isGranted) {
     notificationStatus = await Permission.notification.request();
   }
-  if (notificationStatus.isGranted) {
+  var foregroundStatus = PermissionStatus.granted;
+  if (Platform.isAndroid && _androidSdkInt() >= 34) {
+    foregroundStatus = await Permission.foregroundService.status;
+    if (!foregroundStatus.isGranted) {
+      foregroundStatus = await Permission.foregroundService.request();
+    }
+  }
+  if (notificationStatus.isGranted && foregroundStatus.isGranted) {
     await initializeBleForegroundService();
   }
   AdaptiveThemeMode? savedThemeMode;


### PR DESCRIPTION
## Summary
- request the Android 14 foreground service permission before starting BLE scanning
- initialize the BLE foreground service only after permission is granted
- document the new Android 14 permission requirement

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630449bbcc83308040f2f50257433e