### PR TITLE
Fix permission handling for Android

### DIFF
--- a/lib/ble_notification_service.dart
+++ b/lib/ble_notification_service.dart
@@ -7,14 +7,13 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'dart:io' show Platform;
+import 'logger.dart';
 
 int _androidSdkInt() {
   if (!Platform.isAndroid) return 0;
   final match = RegExp(r'API (\d+)').firstMatch(Platform.operatingSystemVersion);
   return match != null ? int.tryParse(match.group(1) ?? '') ?? 0 : 0;
 }
-
-import 'logger.dart';
 
 class BleNotificationService {
   BleNotificationService._internal();
@@ -37,7 +36,8 @@ class BleNotificationService {
       Permission.notification,
     ];
     if (Platform.isAndroid && _androidSdkInt() >= 34) {
-      permissions.add(Permission.foregroundService);
+      // No runtime permission exists for foreground services on Android.
+      // Only a manifest declaration is required, so skip requesting it.
     }
     final statuses = await permissions.request();
 
@@ -52,13 +52,7 @@ class BleNotificationService {
     final granted = statuses.values.every((status) => status.isGranted);
     if (!granted) {
       AppLogger.e(
-          'Required BLE permissions not granted. Please grant "Nearby devices", "Post notifications" and "Foreground service (connected device)" permissions in system settings.');
-    }
-    if (Platform.isAndroid && _androidSdkInt() >= 34) {
-      final fgStatus = statuses[Permission.foregroundService];
-      if (!(fgStatus?.isGranted ?? false)) {
-        AppLogger.e('Foreground service permission denied');
-      }
+          'Required BLE permissions not granted. Please grant "Nearby devices" and "Post notifications" permissions in system settings.');
     }
 
     bool locationEnabled = true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,10 +43,9 @@ Future<void> main() async {
   }
   var foregroundStatus = PermissionStatus.granted;
   if (Platform.isAndroid && _androidSdkInt() >= 34) {
-    foregroundStatus = await Permission.foregroundService.status;
-    if (!foregroundStatus.isGranted) {
-      foregroundStatus = await Permission.foregroundService.request();
-    }
+    // The permission_handler plugin does not provide a runtime permission
+    // for foreground services. Android 14 requires a manifest declaration
+    // only, so this step is skipped.
   }
   if (notificationStatus.isGranted && foregroundStatus.isGranted) {
     await initializeBleForegroundService();


### PR DESCRIPTION
## Summary
- move `logger.dart` import before declarations in `BleNotificationService`
- skip requesting non-existent `foregroundService` permission
- update BLE permission message and main startup logic

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686306c4b0f0833093f79a68939a6ce9