### PR TITLE
Fix BLE notification delivery

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -52,6 +52,18 @@ void bleServiceOnStart(ServiceInstance service) async {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
 
+  const AndroidInitializationSettings initializationSettingsAndroid =
+      AndroidInitializationSettings('@mipmap/ic_launcher');
+  const DarwinInitializationSettings initializationSettingsDarwin =
+      DarwinInitializationSettings();
+  const InitializationSettings initializationSettings = InitializationSettings(
+    android: initializationSettingsAndroid,
+    iOS: initializationSettingsDarwin,
+    macOS: initializationSettingsDarwin,
+  );
+
+  await flutterLocalNotificationsPlugin.initialize(initializationSettings);
+
   BleNotificationService.instance.messages.listen((msg) {
     flutterLocalNotificationsPlugin.show(
       msg.hashCode,


### PR DESCRIPTION
## Summary
- initialize `FlutterLocalNotificationsPlugin` in background BLE service

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68642583e91c8330a4e453f319f39883