### PR TITLE
Implement Firebase push notifications for recognized faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ To run this repo successfully, license should be required based on each `applica
   granted and that location services are enabled. On Android 14 and above you
   must also grant the **Foreground service (connected device)** permission when
   requested.
+  For remote notifications, place your `google-services.json` file into
+  `android/app` and make sure a valid Firebase project is configured. Devices
+  will automatically subscribe to the `face_events` topic and receive push
+  notifications when a face is recognized.
   If you plan to run the iOS app, please refer to the following [link](https://docs.flutter.dev/deployment/ios) for detailed instructions.</br>
 ## About SDK
 ### 1. Setup

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,6 +24,7 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'dev.flutter.flutter-gradle-plugin'
+apply plugin: 'com.google.gms.google-services'
 
 android {
     namespace "com.example.facerecognition_flutter"
@@ -75,4 +76,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Required library for core library desugaring
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+    implementation 'com.google.firebase:firebase-messaging:23.4.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'  // Updated to 8.2.1
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.4.1'
     }
 }
 

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -13,6 +13,7 @@ import 'recognition_log.dart';
 import 'localization.dart';
 import 'relay_service.dart';
 import 'ble_notification_service.dart';
+import 'firebase_service.dart';
 
 // ignore: must_be_immutable
 class FaceRecognitionView extends StatefulWidget {
@@ -176,6 +177,11 @@ class FaceRecognitionViewState extends State<FaceRecognitionView> {
           AppLogger.e('Failed to send relay', e, st);
         }
         await BleNotificationService.instance.broadcastName(maxSimilarityName, context: context);
+        try {
+          await FirebaseService.sendNotification(maxSimilarityName);
+        } catch (e, st) {
+          AppLogger.e('Failed to send FCM notification', e, st);
+        }
         await BleNotificationService.instance.startScanning(context: context);
         faceDetectionViewController?.stopCamera();
         setState(() {

--- a/lib/firebase_service.dart
+++ b/lib/firebase_service.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:http/http.dart' as http;
+
+class FirebaseService {
+  FirebaseService._();
+
+  static Future<void> initialize() async {
+    await Firebase.initializeApp();
+    await FirebaseMessaging.instance.requestPermission();
+    await FirebaseMessaging.instance.subscribeToTopic('face_events');
+  }
+
+  // Replace with your actual FCM server key.
+  static const String _serverKey = 'YOUR_SERVER_KEY';
+
+  static Future<void> sendNotification(String name) async {
+    final payload = {
+      'to': '/topics/face_events',
+      'notification': {
+        'title': 'Face Recognized',
+        'body': '$name recognized',
+      },
+      'data': {
+        'name': name,
+      }
+    };
+
+    final response = await http.post(
+      Uri.parse('https://fcm.googleapis.com/fcm/send'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'key=$_serverKey',
+      },
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Failed to send FCM message: ${response.body}');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'recognition_log.dart';
 import 'localization.dart';
 import 'ble_foreground_service.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'firebase_service.dart';
 
 int _androidSdkInt() {
   if (!Platform.isAndroid) return 0;
@@ -37,6 +38,7 @@ final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await FirebaseService.initialize();
   var notificationStatus = await Permission.notification.status;
   if (!notificationStatus.isGranted) {
     notificationStatus = await Permission.notification.request();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,9 @@ dependencies:
   flutter_ble_peripheral: ^1.2.6
   permission_handler: ^12.0.0
   flutter_local_notifications: ^19.3.0
+  firebase_core: ^2.24.2
+  firebase_messaging: ^14.7.10
+  http: ^1.2.1
   flutter_background_service: ^5.1.0
   flutter_background_service_android: ^6.3.0
   flutter_background_service_ios: ^5.0.3


### PR DESCRIPTION
## Summary
- include Firebase dependencies for FCM support
- add Firebase service with initialization and sendNotification helper
- initialize Firebase on app startup
- send FCM push notification when a face is recognized
- configure Android build for google-services
- document Firebase setup in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686429b9e18483309396a6e0b854e287