### PR TITLE
Fix BLE notification visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ To run this repo successfully, license should be required based on each `applica
 ### Offline Notifications via BLE
 This application uses Bluetooth Low Energy to deliver face recognition alerts to nearby devices without requiring an internet connection. Ensure that the BLE foreground service is active and that all participating devices grant the **Nearby devices** and **Location** permissions so advertisements and scans can run in the background.
 
+Local notifications are triggered from the background service. The
+`flutter_local_notifications` plugin must be initialized inside the service's
+isolate; otherwise calls to `show()` will silently fail and no alerts will be
+displayed on other devices.
+
 ## About SDK
 ### 1. Setup
 #### 1.1 Setting Up Face SDK

--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -15,7 +15,8 @@ Future<void> initializeBleForegroundService() async {
     notificationChannelId,
     'BLE Scan',
     description: 'Scanning for BLE messages',
-    importance: Importance.low,
+    // Use default importance so notifications appear visibly
+    importance: Importance.defaultImportance,
   );
 
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =


### PR DESCRIPTION
## Summary
- ensure BLE service notification channel uses default importance so notifications appear
- document the need to initialize `flutter_local_notifications` inside the background service

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68645c5a38ec833082a4d41a01e5d2aa