### PR TITLE
Fix BLE notification delivery

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter_background_service/flutter_background_service.dart';
 import 'package:flutter_background_service_android/flutter_background_service_android.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'ble_notification_service.dart';
+import 'notification_helper.dart';
 
 const String notificationChannelId = 'ble_scan';
 const int notificationId = 999;
@@ -20,12 +21,7 @@ Future<void> initializeBleForegroundService() async {
   );
 
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-      FlutterLocalNotificationsPlugin();
-
-  await flutterLocalNotificationsPlugin
-      .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>()
-      ?.createNotificationChannel(channel);
+      await initLocalNotifications(channel: channel);
 
   await service.configure(
     androidConfiguration: AndroidConfiguration(
@@ -49,24 +45,8 @@ Future<void> initializeBleForegroundService() async {
 @pragma('vm:entry-point')
 void bleServiceOnStart(ServiceInstance service) async {
   DartPluginRegistrant.ensureInitialized();
-
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-      FlutterLocalNotificationsPlugin();
-
-  // Local notifications must be initialized again in the background isolate
-  // otherwise `show()` will silently fail. This was the cause of notifications
-  // not appearing on other devices.
-  const AndroidInitializationSettings initializationSettingsAndroid =
-      AndroidInitializationSettings('@mipmap/ic_launcher');
-  const DarwinInitializationSettings initializationSettingsDarwin =
-      DarwinInitializationSettings();
-  const InitializationSettings initializationSettings = InitializationSettings(
-    android: initializationSettingsAndroid,
-    iOS: initializationSettingsDarwin,
-    macOS: initializationSettingsDarwin,
-  );
-
-  await flutterLocalNotificationsPlugin.initialize(initializationSettings);
+      await initLocalNotifications();
 
   BleNotificationService.instance.messages.listen((msg) {
     flutterLocalNotificationsPlugin.show(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'facesdk_plugin_import.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     hide Person;
+import 'notification_helper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_exif_rotation/flutter_exif_rotation.dart';
 import 'package:path/path.dart' as p;
@@ -32,8 +33,7 @@ int _androidSdkInt() {
   return match != null ? int.tryParse(match.group(1) ?? '') ?? 0 : 0;
 }
 
-final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-    FlutterLocalNotificationsPlugin();
+late final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -65,16 +65,7 @@ Future<void> main() async {
   } catch (_) {
     savedThemeMode = AdaptiveThemeMode.system;
   }
-  const AndroidInitializationSettings initializationSettingsAndroid =
-      AndroidInitializationSettings('@mipmap/ic_launcher');
-  const DarwinInitializationSettings initializationSettingsDarwin =
-      DarwinInitializationSettings();
-  final InitializationSettings initializationSettings = InitializationSettings(
-    android: initializationSettingsAndroid,
-    iOS: initializationSettingsDarwin,
-    macOS: initializationSettingsDarwin,
-  );
-  await flutterLocalNotificationsPlugin.initialize(initializationSettings);
+  flutterLocalNotificationsPlugin = await initLocalNotifications();
   runApp(MyApp(savedThemeMode: savedThemeMode));
 }
 

--- a/lib/notification_helper.dart
+++ b/lib/notification_helper.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+Future<FlutterLocalNotificationsPlugin> initLocalNotifications({AndroidNotificationChannel? channel}) async {
+  final plugin = FlutterLocalNotificationsPlugin();
+  const AndroidInitializationSettings initializationSettingsAndroid =
+      AndroidInitializationSettings('@mipmap/ic_launcher');
+  const DarwinInitializationSettings initializationSettingsDarwin =
+      DarwinInitializationSettings();
+  const InitializationSettings initializationSettings = InitializationSettings(
+    android: initializationSettingsAndroid,
+    iOS: initializationSettingsDarwin,
+    macOS: initializationSettingsDarwin,
+  );
+  await plugin.initialize(initializationSettings);
+  if (channel != null) {
+    await plugin
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
+  }
+  return plugin;
+}


### PR DESCRIPTION
## Summary
- refactor BLE service to use shared notification initializer
- expose `initLocalNotifications` helper

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68645dd16bcc83309952e052d2a7982d