### PR TITLE
Fix BLE notifications

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -44,6 +44,8 @@ Future<void> initializeBleForegroundService() async {
 
 @pragma('vm:entry-point')
 void bleServiceOnStart(ServiceInstance service) async {
+  // Ensure all plugins and bindings are ready for use in this isolate
+  WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
       await initLocalNotifications();


### PR DESCRIPTION
## Summary
- ensure WidgetsFlutterBinding initialized in BLE foreground service

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645faea8f48330b6fe82846629d7a1