### PR TITLE
Fix BLE notifications

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -20,8 +20,9 @@ Future<void> initializeBleForegroundService() async {
     importance: Importance.defaultImportance,
   );
 
-  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-      await initLocalNotifications(channel: channel);
+  // Initialize the notification plugin so the background isolate
+  // can display alerts when BLE messages arrive.
+  await initLocalNotifications(channel: channel);
 
   await service.configure(
     androidConfiguration: AndroidConfiguration(


### PR DESCRIPTION
## Summary
- ensure `initLocalNotifications` returns side effects without unused vars
- keep notification initialization in the BLE service startup

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686460bf85388330aad42ce618e4de58