### PR TITLE
Fix offline BLE notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ This application uses Bluetooth Low Energy to deliver face recognition alerts to
 
 Local notifications are triggered from the background service. The
 `flutter_local_notifications` plugin must be initialized inside the service's
-isolate; otherwise calls to `show()` will silently fail and no alerts will be
-displayed on other devices.
+isolate using the same notification channel; otherwise calls to `show()` will
+silently fail and no alerts will be displayed on other devices.
 
 ## About SDK
 ### 1. Setup

--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -43,13 +43,19 @@ Future<void> initializeBleForegroundService() async {
   await service.startService();
 }
 
-@pragma('vm:entry-point')
+  @pragma('vm:entry-point')
 void bleServiceOnStart(ServiceInstance service) async {
   // Ensure all plugins and bindings are ready for use in this isolate
   WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
+  const AndroidNotificationChannel channel = AndroidNotificationChannel(
+    notificationChannelId,
+    'BLE Scan',
+    description: 'Scanning for BLE messages',
+    importance: Importance.defaultImportance,
+  );
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-      await initLocalNotifications();
+      await initLocalNotifications(channel: channel);
 
   BleNotificationService.instance.messages.listen((msg) {
     flutterLocalNotificationsPlugin.show(


### PR DESCRIPTION
## Summary
- ensure BLE foreground service initializes `flutter_local_notifications` with the notification channel
- clarify README instructions about plugin initialization

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686461da974c8330adb698d842c57275