### PR TITLE
Fix BLE notifications after app closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Local notifications are triggered from the background service. The
 `flutter_local_notifications` plugin must be initialized inside the service's
 isolate using the same notification channel; otherwise calls to `show()` will
 silently fail and no alerts will be displayed on other devices.
+The foreground service entry in `AndroidManifest.xml` now sets
+`android:stopWithTask="false"` so scanning continues even if the app is removed
+from the recent tasks list.
 
 ## About SDK
 ### 1. Setup

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:exported="false"
             android:foregroundServiceType="connectedDevice"
+            android:stopWithTask="false"
             tools:replace="android:exported" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
## Summary
- keep the background BLE service running when the app is removed from recents by adding `stopWithTask` to the manifest
- document this requirement in the README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864631c6d448330b82e28e667659788