### PR TITLE
Fix BLE notification channel mismatch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -503,11 +503,10 @@ class MyHomePageState extends State<MyHomePage> {
 
   Future<void> _showNotification(String name) async {
     const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
-      'face_channel',
-      'Face Notifications',
-      channelDescription: 'Notifications for face recognition',
-      importance: Importance.max,
-      priority: Priority.high,
+      notificationChannelId,
+      'BLE Scan',
+      channelDescription: 'Scanning for BLE messages',
+      importance: Importance.defaultImportance,
     );
     const NotificationDetails notificationDetails =
         NotificationDetails(android: androidDetails);


### PR DESCRIPTION
## Summary
- fix notifications not delivered by using the same BLE notification channel in the app

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686464b8ba1c833087a17ccb9e6d70d0