### PR TITLE
Fix missing import for WidgetsFlutterBinding

### DIFF
--- a/lib/ble_foreground_service.dart
+++ b/lib/ble_foreground_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_background_service/flutter_background_service.dart';
 import 'package:flutter_background_service_android/flutter_background_service_android.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';


### PR DESCRIPTION
## Summary
- add `package:flutter/widgets.dart` to use `WidgetsFlutterBinding`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864665cf31c8330b4b192c426a028ac