### PR TITLE
Add language selection on sign-up

### DIFF
--- a/lib/signup_page.dart
+++ b/lib/signup_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'account.dart';
 import 'account_service.dart';
 import 'localization.dart';
+import 'main.dart';
 
 class SignUpPage extends StatefulWidget {
   final void Function(Account) onFinished;
@@ -14,6 +16,30 @@ class SignUpPage extends StatefulWidget {
 class _SignUpPageState extends State<SignUpPage> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  int _selectedLanguage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLanguage();
+  }
+
+  Future<void> _loadLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString('language_code') ?? 'en';
+    setState(() {
+      _selectedLanguage = code == 'tr' ? 1 : 0;
+    });
+  }
+
+  Future<void> _updateLanguage(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('language_code', value == 1 ? 'tr' : 'en');
+    setState(() {
+      _selectedLanguage = value;
+    });
+    MyApp.setLocale(context, Locale(value == 1 ? 'tr' : 'en'));
+  }
 
   Future<void> _create() async {
     final account = Account(
@@ -30,27 +56,59 @@ class _SignUpPageState extends State<SignUpPage> {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context).t('createAccount')),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _usernameController,
-              decoration: InputDecoration(
-                  labelText: AppLocalizations.of(context).t('username')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  DropdownButton<int>(
+                    value: _selectedLanguage,
+                    onChanged: (int? value) {
+                      if (value != null) _updateLanguage(value);
+                    },
+                    items: [
+                      DropdownMenuItem(
+                        value: 0,
+                        child: Text(AppLocalizations.of(context).t('english')),
+                      ),
+                      DropdownMenuItem(
+                        value: 1,
+                        child: Text(AppLocalizations.of(context).t('turkish')),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _usernameController,
+                    decoration: InputDecoration(
+                      labelText:
+                          AppLocalizations.of(context).t('username'),
+                    ),
+                  ),
+                  TextField(
+                    controller: _passwordController,
+                    decoration: InputDecoration(
+                      labelText:
+                          AppLocalizations.of(context).t('password'),
+                    ),
+                    obscureText: true,
+                  ),
+                  const SizedBox(height: 16),
+                  FilledButton(
+                    onPressed: _create,
+                    child: Text(
+                        AppLocalizations.of(context).t('createAccount')),
+                  )
+                ],
+              ),
             ),
-            TextField(
-              controller: _passwordController,
-              decoration: InputDecoration(
-                  labelText: AppLocalizations.of(context).t('password')),
-              obscureText: true,
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: _create,
-              child: Text(AppLocalizations.of(context).t('createAccount')),
-            )
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- enable choosing app language on sign-up page
- persist language using `SharedPreferences`
- improve first-run sign-up layout with a centered card

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687184981d848330a731c35d1a778328