### PR TITLE
Fix missing SDK initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -240,6 +240,9 @@ class MyHomePageState extends State<MyHomePage> {
       }
 
 
+      // Initialize FaceSDK so that recognition and capture work correctly.
+      await _facesdkPlugin.init();
+
       personList = await loadAllPersons();
       logList = await loadAllLogs();
       await SettingsPageState.initSettings();


### PR DESCRIPTION
## Summary
- initialize FaceSDK during startup

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718a3d4c1c8330a267676969d9327b