### PR TITLE
Fix FaceSDK init for capture/detect

### DIFF
--- a/lib/facecaptureview.dart
+++ b/lib/facecaptureview.dart
@@ -673,6 +673,9 @@ class _FaceCaptureDetectionViewState extends State<FaceCaptureDetectionView> {
     widget.faceRecognitionViewState.faceDetectionViewController =
         FaceDetectionViewController(id, widget);
 
+    // Ensure FaceSDK is initialized before interacting with the native view.
+    await widget.faceRecognitionViewState._facesdkPlugin.init();
+
     await widget.faceRecognitionViewState.faceDetectionViewController
         ?.initHandler();
 

--- a/lib/facedetectionview.dart
+++ b/lib/facedetectionview.dart
@@ -474,6 +474,9 @@ class _FaceDetectionViewState extends State<FaceDetectionView> {
     widget.faceRecognitionViewState.faceDetectionViewController =
         FaceDetectionViewController(id, widget);
 
+    // Ensure FaceSDK is initialized before interacting with the native view.
+    await widget.faceRecognitionViewState._facesdkPlugin.init();
+
     await widget.faceRecognitionViewState.faceDetectionViewController
         ?.initHandler();
 


### PR DESCRIPTION
## Summary
- ensure the face plugin is initialized when a camera view is created

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718e0500e0833082ec08ffbf3696e2